### PR TITLE
VCDA:168 & 169 : vcd-cli for Attach or Detach Independent Disk to/from a VM within a vApp

### DIFF
--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -106,6 +106,7 @@ def info(ctx, name):
     except Exception as e:
         stderr(e, ctx)
 
+
 @vapp.command(short_help='Attach disk to VM in vApp')
 @click.pass_context
 @click.argument('vapp_name',
@@ -125,10 +126,15 @@ def attach(ctx, vapp_name, vm_name, disk_name):
         disk = vdc.get_disk(disk_name)
         vapp_resource = vdc.get_vapp(vapp_name)
         vapp = VApp(client, resource=vapp_resource)
-        task = vapp.attach_disk_to_vm(disk_href=disk.get('href'),disk_type=disk.get('type'),disk_name=disk_name,  vm_name=vm_name)
+        task = vapp.attach_disk_to_vm(
+            disk_href=disk.get('href'),
+            disk_type=disk.get('type'),
+            disk_name=disk_name,
+            vm_name=vm_name)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
+
 
 @vapp.command(short_help='Detach disk from VM in vApp')
 @click.pass_context
@@ -149,7 +155,11 @@ def detach(ctx, vapp_name, vm_name, disk_name):
         disk = vdc.get_disk(disk_name)
         vapp_resource = vdc.get_vapp(vapp_name)
         vapp = VApp(client, resource=vapp_resource)
-        task = vapp.detach_disk_from_vm(disk_href=disk.get('href'),disk_type=disk.get('type'),disk_name=disk_name,  vm_name=vm_name)
+        task = vapp.detach_disk_from_vm(
+            disk_href=disk.get('href'),
+            disk_type=disk.get('type'),
+            disk_name=disk_name,
+            vm_name=vm_name)
         stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)

--- a/vcd_cli/vapp.py
+++ b/vcd_cli/vapp.py
@@ -71,6 +71,12 @@ def vapp(ctx):
 \b
         vcd vapp capture my-vapp my-catalog
             Capture a vApp as a template in a catalog.
+\b
+        vcd vapp attach my-vapp my-vm disk-name
+            Attach a disk to a vm in the given vapp.
+\b
+        vcd vapp detach my-vapp my-vm disk-name
+            Detach a disk from a vm in the given vapp.
     """  # NOQA
     if ctx.invoked_subcommand is not None:
         try:
@@ -96,6 +102,54 @@ def info(ctx, name):
         vapp = VApp(client, resource=vapp_resource)
         md = vapp.get_metadata()
         stdout(vapp_to_dict(vapp_resource, md), ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vapp.command(short_help='Attach disk to VM in vApp')
+@click.pass_context
+@click.argument('vapp_name',
+                metavar='<vapp_name>',
+                required=True)
+@click.argument('vm-name',
+                metavar='<vm-name>',
+                required=True)
+@click.argument('disk-name',
+                metavar='<disk-name>',
+                required=True)
+def attach(ctx, vapp_name, vm_name, disk_name):
+    try:
+        client = ctx.obj['client']
+        vdc_href = ctx.obj['profiles'].get('vdc_href')
+        vdc = VDC(client, href=vdc_href)
+        disk = vdc.get_disk(disk_name)
+        vapp_resource = vdc.get_vapp(vapp_name)
+        vapp = VApp(client, resource=vapp_resource)
+        task = vapp.attach_disk_to_vm(disk_href=disk.get('href'),disk_type=disk.get('type'),disk_name=disk_name,  vm_name=vm_name)
+        stdout(task, ctx)
+    except Exception as e:
+        stderr(e, ctx)
+
+@vapp.command(short_help='Detach disk from VM in vApp')
+@click.pass_context
+@click.argument('vapp_name',
+                metavar='<vapp_name>',
+                required=True)
+@click.argument('vm-name',
+                metavar='<vm-name>',
+                required=True)
+@click.argument('disk-name',
+                metavar='<disk-name>',
+                required=True)
+def detach(ctx, vapp_name, vm_name, disk_name):
+    try:
+        client = ctx.obj['client']
+        vdc_href = ctx.obj['profiles'].get('vdc_href')
+        vdc = VDC(client, href=vdc_href)
+        disk = vdc.get_disk(disk_name)
+        vapp_resource = vdc.get_vapp(vapp_name)
+        vapp = VApp(client, resource=vapp_resource)
+        task = vapp.detach_disk_from_vm(disk_href=disk.get('href'),disk_type=disk.get('type'),disk_name=disk_name,  vm_name=vm_name)
+        stdout(task, ctx)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
python -m unittest vcd_vapp.TestVApp.test_101_attach_disk_to_vm_in_vapp
/Users/malakars/.virtualenvs/pyvcloud/lib/python3.6/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
.
----------------------------------------------------------------------
Ran 1 test in 20.973s

OK
sys:1: ResourceWarning: unclosed <ssl.SSLSocket fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 63941), raddr=('127.0.0.1', 8443)>
(pyvcloud) malakars-m01:tests malakars$ python -m unittest vcd_vapp.TestVApp.test_001_detach_disk_from_vm_in_vapp
/Users/malakars/.virtualenvs/pyvcloud/lib/python3.6/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
.
----------------------------------------------------------------------
Ran 1 test in 14.808s

OK
